### PR TITLE
Use newer libftdi

### DIFF
--- a/ft2232_spi.c
+++ b/ft2232_spi.c
@@ -30,12 +30,6 @@
 #include "spi.h"
 #include <ftdi.h>
 
-/* This is not defined in libftdi.h <0.20 (c7e4c09e68cfa6f5e112334aa1b3bb23401c8dc7 to be exact).
- * Some tests indicate that his is the only change that it is needed to support the FT232H in flashrom. */
-#if !defined(HAVE_FT232H)
-#define TYPE_232H	6
-#endif
-
 /* Please keep sorted by vendor ID, then device ID. */
 
 #define FTDI_VID		0x0403


### PR DESCRIPTION
In Fedora 22, flashrom ships with ft2232_spi disabled because the old libftdi (0.2) is no longer packaged. I expect the situation to be similar in other modern distros as well. That's mostly because the package "libftdi" was renamed to "libftdi1", but it is a big enough issue that ftdi-based programmers are being disabled.