### PR TITLE
Cleanup of serprog-improvements

### DIFF
--- a/82802ab.c
+++ b/82802ab.c
@@ -86,16 +86,14 @@ int probe_82802ab(struct flashctx *flash)
 	return 1;
 }
 
-/* FIXME: needs timeout */
 uint8_t wait_82802ab(struct flashctx *flash)
 {
 	uint8_t status;
 	chipaddr bios = flash->virtual_memory;
 
 	chip_writeb(flash, 0x70, bios);
-	if ((chip_readb(flash, bios) & 0x80) == 0) {	// it's busy
-		while ((chip_readb(flash, bios) & 0x80) == 0) ;
-	}
+
+	chip_poll(flash, bios, 0x80, 0, 0);
 
 	status = chip_readb(flash, bios);
 

--- a/Documentation/serprog-protocol.txt
+++ b/Documentation/serprog-protocol.txt
@@ -53,7 +53,7 @@ Additional information of the above commands:
 		cmd 8 support: byte 1 bit 0, and so on.
 	0x04 (Q_SERBUF):
 		If the programmer has a guaranteed working flow control,
-		it should return a big bogus value - eg 0xFFFF.
+		it should return a suitable transfer window size for the connection, eg. ~4k for usb-serial.
 	0x05 (Q_BUSTYPE):
 		The bit's are defined as follows:
 		bit 0: PARALLEL, bit 1: LPC, bit 2: FWH, bit 3: SPI.
@@ -118,5 +118,43 @@ Additional information of the above commands:
 		S_CMD_O_DELAY, S_CMD_O_EXEC.
 		In addition, support for these commands is recommended:
 		S_CMD_Q_PGMNAME, S_CMD_Q_BUSTYPE, S_CMD_Q_CHIPSIZE (if parallel).
+
+
+Operation buffer details and rationale
+--------------------------------------
+The operation buffer is an area of memory on the programming device used to hold
+write-related operations so they can be executed in quick succession after
+the whole operation has been transferred to the device.
+This is required (with some non-SPI chips) to be able to perform a page load
+quickly enough if connection is a slow serial, since they have a page load timeout.
+
+The operations in opbuf take the same amount of space/bytes they used on-wire when
+being transferred, but the representation of them in the opbuf is upto the implementation.
+
+Write to opbuf operations should return NAK in case of an attempted buffer overflow,
+but the state of the buffer after such a NAK is unknown and the programmer
+should be reinitialized (atleast S_CMD_O_INIT) if this happens.
+
+S_CMD_O_INIT is meant to be only used when the device is in unknown state,
+meaning once in the beginning of operations. S_CMD_O_EXEC will attempt to execute
+the operation buffer and _always_ clear it after the attempt. It can return NAK
+in the case of a programmer internal error (hw fail/bug), but there are no
+"normal"/expected error conditions except previous overflow attempt
+(which is not a normal operation either).
+
+For SPI-only devices the opbuf support is delays-only (SPIOP is immediate),
+and both of these implementation styles are allowed:
+1:
+O_INIT clears internal delay count
+O_DELAY adds to internal delay count
+O_EXEC "executes" internal delay count
+2:
+O_INIT is a nop
+O_DELAY executes specified delay
+O_EXEC is a nop
+
+Regardless of the implementation style, all 3 opcodes need to be marked as
+supported and return ACK, and reported operation buffer size should be big
+enough to fit atleast 2 delays.
 
 See also serprog.h.

--- a/Documentation/serprog-protocol.txt
+++ b/Documentation/serprog-protocol.txt
@@ -35,6 +35,8 @@ COMMAND	Description			Parameters			Return Value
 					 + slen bytes of data
 0x14	Set SPI clock frequency in Hz	32-bit requested frequency	ACK + 32-bit set frequency / NAK
 0x15	Toggle flash chip pin drivers	8-bit (0 disable, else enable)	ACK / NAK
+0x17	Write to opbuf: poll		8-bit flags + 24-bit addr	ACK / NAK
+0x18	Write to opbuf: poll w/ delay	as above + 32-bit usecs		ACK / NAK
 0x??	unimplemented command - invalid.
 
 
@@ -89,6 +91,24 @@ Additional information of the above commands:
 		remain attached to the flash chip even when the board is running. The user is responsible to
 		NOT connect VCC and other permanently externally driven signals to the programmer as needed.
 		If the value is 0, then the drivers should be disabled, otherwise they should be enabled.
+	0x17 and 0x18 (S_CMD_O_POLL and + _DLY):
+		flags: 0b00DT0BBB where T = toggle mode = 1 / data mode = 0, D = data bit in data mode,
+			B = bit to monitor (0-7). Unused bits (0) are not checked on device.
+		Implements algorithm to wait for flash chip to be ready before continuing opbuf
+		execution (pseudocode with C-like operators):
+			i = 0
+			mask = 1 << bit
+			if (toggle mode)
+				tmp1 = flash_read(addr) & mask
+			else
+				tmp1 = data_bit ? mask : 0
+
+			while (i++ < 0xFFFFFFF)  // Device can adjust timeout relative to own speed
+				delay (if _DLY version)
+				tmp2 = flash_read(addr) & mask
+				if (tmp1 == tmp2) break
+				if (toggle mode) tmp1 = tmp2
+
 	About mandatory commands:
 		The only truly mandatory commands for any device are 0x00, 0x01, 0x02 and 0x10,
 		but one can't really do anything with these commands.

--- a/atahpt.c
+++ b/atahpt.c
@@ -56,6 +56,7 @@ static const struct par_master par_master_atahpt = {
 		.chip_writew		= fallback_chip_writew,
 		.chip_writel		= fallback_chip_writel,
 		.chip_writen		= fallback_chip_writen,
+		.chip_poll		= fallback_chip_poll,
 };
 
 int atahpt_init(void)

--- a/atavia.c
+++ b/atavia.c
@@ -69,6 +69,7 @@ static const struct par_master lpc_master_atavia = {
 		.chip_writew		= fallback_chip_writew,
 		.chip_writel		= fallback_chip_writel,
 		.chip_writen		= fallback_chip_writen,
+		.chip_poll		= fallback_chip_poll,
 };
 
 static void *atavia_offset = NULL;

--- a/drkaiser.c
+++ b/drkaiser.c
@@ -54,6 +54,7 @@ static const struct par_master par_master_drkaiser = {
 		.chip_writew		= fallback_chip_writew,
 		.chip_writel		= fallback_chip_writel,
 		.chip_writen		= fallback_chip_writen,
+		.chip_poll		= fallback_chip_poll,
 };
 
 int drkaiser_init(void)

--- a/dummyflasher.c
+++ b/dummyflasher.c
@@ -129,6 +129,7 @@ static const struct par_master par_master_dummy = {
 		.chip_writew		= dummy_chip_writew,
 		.chip_writel		= dummy_chip_writel,
 		.chip_writen		= dummy_chip_writen,
+		.chip_poll		= fallback_chip_poll,
 };
 
 enum chipbustype dummy_buses_supported = BUS_NONE;

--- a/flash.h
+++ b/flash.h
@@ -245,6 +245,8 @@ uint8_t chip_readb(const struct flashctx *flash, const chipaddr addr);
 uint16_t chip_readw(const struct flashctx *flash, const chipaddr addr);
 uint32_t chip_readl(const struct flashctx *flash, const chipaddr addr);
 void chip_readn(const struct flashctx *flash, uint8_t *buf, const chipaddr addr, size_t len);
+void chip_poll(const struct flashctx *flash, const chipaddr addr, uint8_t mask,
+		int data_or_toggle, unsigned int delay);
 
 /* print.c */
 int print_supported(void);

--- a/flashrom.8.tmpl
+++ b/flashrom.8.tmpl
@@ -203,10 +203,9 @@ JTAGkey/JTAGkey-tiny/JTAGkey-2, Dangerous Prototypes Bus Blaster, \
 Olimex ARM-USB-TINY/-H, Olimex ARM-USB-OCD/-H, TIAO/DIYGADGET USB
 Multi-Protocol Adapter (TUMPA), TUMPA Lite, and GOEPEL PicoTAP.
 .sp
-.BR "* serprog" " (for flash ROMs attached to a programmer speaking serprog), \
-including AVR flasher by Urja Rannikko, AVR flasher by eightdot, \
-Arduino Mega flasher by fritz, InSystemFlasher by Juhana Helovuo, and \
-atmegaXXu2-flasher by Stefan Tauner."
+.BR "* serprog" " (for flash ROMs attached to a programmer speaking serprog, \
+including Arduino-based devices as well as various programmers by Urja Rannikko, \
+Juhana Helovuo, Stefan Tauner and others)."
 .sp
 .BR "* buspirate_spi" " (for SPI flash ROMs attached to a Bus Pirate)"
 .sp
@@ -683,19 +682,22 @@ parameter with the
 syntax.
 .SS
 .BR "serprog " programmer
-A mandatory parameter specifies either a serial
-device/baud combination or an IP/port combination for communication with the
-programmer. In the device/baud combination, the device has to start with a
-slash. For serial, you have to use the
+A mandatory parameter specifies either a serial device (and baud rate) or an IP/port combination for
+communicating with the programmer.
+The device/baud combination has to start with
+.B dev=
+and separate the optional baud rate with a colon.
+For example
 .sp
-.B "  flashrom \-p serprog:dev=/dev/device:baud"
+.B "  flashrom \-p serprog:dev=/dev/ttyS0:115200"
 .sp
-syntax and for IP, you have to use
+If no baud rate is given the default values by the operating system/hardware will be used.
+For IP connections you have to use the
 .sp
 .B "  flashrom \-p serprog:ip=ipaddr:port"
 .sp
-instead. In case the device supports it, you can set the SPI clock frequency
-with the optional
+syntax.
+In case the device supports it, you can set the SPI clock frequency with the optional
 .B spispeed
 parameter. The frequency is parsed as hertz, unless an
 .BR M ", or " k

--- a/flashrom.c
+++ b/flashrom.c
@@ -554,6 +554,12 @@ void chip_readn(const struct flashctx *flash, uint8_t *buf, chipaddr addr,
 	flash->mst->par.chip_readn(flash, buf, addr, len);
 }
 
+void chip_poll(const struct flashctx *flash, const  chipaddr addr,
+		uint8_t mask, int data_or_toggle, unsigned int delay)
+{
+	flash->mst->par.chip_poll(flash, addr, mask, data_or_toggle, delay);
+}
+
 void programmer_delay(unsigned int usecs)
 {
 	if (usecs > 0)

--- a/gfxnvidia.c
+++ b/gfxnvidia.c
@@ -75,6 +75,7 @@ static const struct par_master par_master_gfxnvidia = {
 		.chip_writew		= fallback_chip_writew,
 		.chip_writel		= fallback_chip_writel,
 		.chip_writen		= fallback_chip_writen,
+		.chip_poll		= fallback_chip_poll,
 };
 
 int gfxnvidia_init(void)

--- a/internal.c
+++ b/internal.c
@@ -154,6 +154,7 @@ static const struct par_master par_master_internal = {
 		.chip_writew		= internal_chip_writew,
 		.chip_writel		= internal_chip_writel,
 		.chip_writen		= fallback_chip_writen,
+		.chip_poll		= fallback_chip_poll,
 };
 
 enum chipbustype internal_buses_supported = BUS_NONE;

--- a/it8212.c
+++ b/it8212.c
@@ -47,6 +47,7 @@ static const struct par_master par_master_it8212 = {
 		.chip_writew		= fallback_chip_writew,
 		.chip_writel		= fallback_chip_writel,
 		.chip_writen		= fallback_chip_writen,
+		.chip_poll		= fallback_chip_poll,
 };
 
 int it8212_init(void)

--- a/jedec.c
+++ b/jedec.c
@@ -43,22 +43,7 @@ uint8_t oddparity(uint8_t val)
 
 static void toggle_ready_jedec_common(const struct flashctx *flash, chipaddr dst, unsigned int delay)
 {
-	unsigned int i = 0;
-	uint8_t tmp1, tmp2;
-
-	tmp1 = chip_readb(flash, dst) & 0x40;
-
-	while (i++ < 0xFFFFFFF) {
-		if (delay)
-			programmer_delay(delay);
-		tmp2 = chip_readb(flash, dst) & 0x40;
-		if (tmp1 == tmp2) {
-			break;
-		}
-		tmp1 = tmp2;
-	}
-	if (i > 0x100000)
-		msg_cdbg("%s: excessive loops, i=0x%x\n", __func__, i);
+	chip_poll(flash, dst, 0x40, -1, delay);
 }
 
 void toggle_ready_jedec(const struct flashctx *flash, chipaddr dst)
@@ -81,19 +66,7 @@ static void toggle_ready_jedec_slow(const struct flashctx *flash, chipaddr dst)
 void data_polling_jedec(const struct flashctx *flash, chipaddr dst,
 			uint8_t data)
 {
-	unsigned int i = 0;
-	uint8_t tmp;
-
-	data &= 0x80;
-
-	while (i++ < 0xFFFFFFF) {
-		tmp = chip_readb(flash, dst) & 0x80;
-		if (tmp == data) {
-			break;
-		}
-	}
-	if (i > 0x100000)
-		msg_cdbg("%s: excessive loops, i=0x%x\n", __func__, i);
+	chip_poll(flash, dst, 0x80, data, 0);
 }
 
 static unsigned int getaddrmask(const struct flashchip *chip)

--- a/nic3com.c
+++ b/nic3com.c
@@ -70,6 +70,7 @@ static const struct par_master par_master_nic3com = {
 		.chip_writew		= fallback_chip_writew,
 		.chip_writel		= fallback_chip_writel,
 		.chip_writen		= fallback_chip_writen,
+		.chip_poll		= fallback_chip_poll,
 };
 
 static int nic3com_shutdown(void *data)

--- a/nicintel.c
+++ b/nicintel.c
@@ -57,6 +57,7 @@ static const struct par_master par_master_nicintel = {
 		.chip_writew		= fallback_chip_writew,
 		.chip_writel		= fallback_chip_writel,
 		.chip_writen		= fallback_chip_writen,
+		.chip_poll		= fallback_chip_poll,
 };
 
 int nicintel_init(void)

--- a/nicnatsemi.c
+++ b/nicnatsemi.c
@@ -51,6 +51,7 @@ static const struct par_master par_master_nicnatsemi = {
 		.chip_writew		= fallback_chip_writew,
 		.chip_writel		= fallback_chip_writel,
 		.chip_writen		= fallback_chip_writen,
+		.chip_poll		= fallback_chip_poll,
 };
 
 int nicnatsemi_init(void)

--- a/nicrealtek.c
+++ b/nicrealtek.c
@@ -50,6 +50,7 @@ static const struct par_master par_master_nicrealtek = {
 		.chip_writew		= fallback_chip_writew,
 		.chip_writel		= fallback_chip_writel,
 		.chip_writen		= fallback_chip_writen,
+		.chip_poll		= fallback_chip_poll,
 };
 
 static int nicrealtek_shutdown(void *data)

--- a/programmer.h
+++ b/programmer.h
@@ -719,10 +719,8 @@ typedef int fdtype;
 #endif
 
 void sp_flush_incoming(void);
-fdtype sp_openserport(char *dev, unsigned int baud);
-int serialport_config(fdtype fd, unsigned int baud);
+fdtype sp_openserport(char *dev, int baud);
 extern fdtype sp_fd;
-/* expose serialport_shutdown as it's currently used by buspirate */
 int serialport_shutdown(void *data);
 int serialport_write(const unsigned char *buf, unsigned int writecnt);
 int serialport_write_nonblock(const unsigned char *buf, unsigned int writecnt, unsigned int timeout, unsigned int *really_wrote);

--- a/programmer.h
+++ b/programmer.h
@@ -678,6 +678,8 @@ void fallback_chip_writen(const struct flashctx *flash, const uint8_t *buf, chip
 uint16_t fallback_chip_readw(const struct flashctx *flash, const chipaddr addr);
 uint32_t fallback_chip_readl(const struct flashctx *flash, const chipaddr addr);
 void fallback_chip_readn(const struct flashctx *flash, uint8_t *buf, const chipaddr addr, size_t len);
+void fallback_chip_poll(const struct flashctx *flash, const chipaddr addr, uint8_t mask,
+			int data_or_toggle, unsigned int delay);
 struct par_master {
 	void (*chip_writeb) (const struct flashctx *flash, uint8_t val, chipaddr addr);
 	void (*chip_writew) (const struct flashctx *flash, uint16_t val, chipaddr addr);
@@ -687,6 +689,8 @@ struct par_master {
 	uint16_t (*chip_readw) (const struct flashctx *flash, const chipaddr addr);
 	uint32_t (*chip_readl) (const struct flashctx *flash, const chipaddr addr);
 	void (*chip_readn) (const struct flashctx *flash, uint8_t *buf, const chipaddr addr, size_t len);
+	void (*chip_poll) (const struct flashctx *flash, const chipaddr addr, uint8_t mask,
+				int data_or_toggle, unsigned int delay);
 	const void *data;
 };
 int register_par_master(const struct par_master *mst, const enum chipbustype buses);

--- a/satamv.c
+++ b/satamv.c
@@ -55,6 +55,7 @@ static const struct par_master par_master_satamv = {
 		.chip_writew		= fallback_chip_writew,
 		.chip_writel		= fallback_chip_writel,
 		.chip_writen		= fallback_chip_writen,
+		.chip_poll		= fallback_chip_poll,
 };
 
 /*

--- a/satasii.c
+++ b/satasii.c
@@ -52,6 +52,7 @@ static const struct par_master par_master_satasii = {
 		.chip_writew		= fallback_chip_writew,
 		.chip_writel		= fallback_chip_writel,
 		.chip_writen		= fallback_chip_writen,
+		.chip_poll		= fallback_chip_poll,
 };
 
 static uint32_t satasii_wait_done(void)

--- a/serial.c
+++ b/serial.c
@@ -209,12 +209,25 @@ int serialport_config(fdtype fd, unsigned int baud)
 	if (observed.c_cflag != wanted.c_cflag ||
 	    observed.c_lflag != wanted.c_lflag ||
 	    observed.c_iflag != wanted.c_iflag ||
-	    observed.c_oflag != wanted.c_oflag ||
-	    cfgetispeed(&observed) != cfgetispeed(&wanted)) {
-		msg_perr("%s: Some requested options did not stick.\n", __func__);
-		return 1;
+	    observed.c_oflag != wanted.c_oflag) {
+		msg_pwarn("Some requested serial options did not stick, continuing anyway.\n");
+		msg_pdbg("          observed    wanted\n"
+			 "c_cflag:  0x%08X  0x%08X\n"
+			 "c_lflag:  0x%08X  0x%08X\n"
+			 "c_iflag:  0x%08X  0x%08X\n"
+			 "c_oflag:  0x%08X  0x%08X\n",
+			 observed.c_cflag, wanted.c_cflag,
+			 observed.c_lflag, wanted.c_lflag,
+			 observed.c_iflag, wanted.c_iflag,
+			 observed.c_oflag, wanted.c_oflag
+			);
 	}
-	msg_pdbg("Baud rate is %d now.\n", entry->baud);
+	if (cfgetispeed(&observed) != cfgetispeed(&wanted) ||
+	    cfgetospeed(&observed) != cfgetospeed(&wanted)) {
+		msg_pwarn("Could not set baud rates exactly\n");
+		msg_pdbg("Actual baud flags are: ispeed: 0x%08lX, ospeed: 0x%08lX\n",
+			  (long)cfgetispeed(&observed), (long)cfgetispeed(&wanted));
+	}
 #endif
 	return 0;
 }

--- a/serial.c
+++ b/serial.c
@@ -43,74 +43,67 @@
 
 fdtype sp_fd = SER_INV_FD;
 
-#if IS_WINDOWS
-struct baudentry {
-	DWORD flag;
-	unsigned int baud;
-};
-#define BAUDENTRY(baud) { CBR_##baud, baud },
-#else
+#if !IS_WINDOWS
 struct baudentry {
 	int flag;
 	unsigned int baud;
 };
 #define BAUDENTRY(baud) { B##baud, baud },
-#endif
 
 /* I'd like if the C preprocessor could have directives in macros.
  * See TERMIOS(3) and http://msdn.microsoft.com/en-us/library/windows/desktop/aa363214(v=vs.85).aspx and
  * http://git.kernel.org/?p=linux/kernel/git/torvalds/linux.git;a=blob;f=include/uapi/asm-generic/termbits.h */
 static const struct baudentry sp_baudtable[] = {
 	BAUDENTRY(9600) /* unconditional default */
-#if defined(B19200) || defined(CBR_19200)
+#ifdef B19200
 	BAUDENTRY(19200)
 #endif
-#if defined(B38400) || defined(CBR_38400)
+#ifdef B38400
 	BAUDENTRY(38400)
 #endif
-#if defined(B57600) || defined(CBR_57600)
+#ifdef B57600
 	BAUDENTRY(57600)
 #endif
-#if defined(B115200) || defined(CBR_115200)
+#ifdef B115200
 	BAUDENTRY(115200)
 #endif
-#if defined(B230400) || defined(CBR_230400)
+#ifdef B230400
 	BAUDENTRY(230400)
 #endif
-#if defined(B460800) || defined(CBR_460800)
+#ifdef B460800
 	BAUDENTRY(460800)
 #endif
-#if defined(B500000) || defined(CBR_500000)
+#ifdef B500000
 	BAUDENTRY(500000)
 #endif
-#if defined(B576000) || defined(CBR_576000)
+#ifdef B576000
 	BAUDENTRY(576000)
 #endif
-#if defined(B921600) || defined(CBR_921600)
+#ifdef B921600
 	BAUDENTRY(921600)
 #endif
-#if defined(B1000000) || defined(CBR_1000000)
+#ifdef B1000000
 	BAUDENTRY(1000000)
 #endif
-#if defined(B1152000) || defined(CBR_1152000)
+#ifdef B1152000
 	BAUDENTRY(1152000)
 #endif
-#if defined(B1500000) || defined(CBR_1500000)
+#ifdef B1500000
 	BAUDENTRY(1500000)
 #endif
-#if defined(B2000000) || defined(CBR_2000000)
+#ifdef B2000000
 	BAUDENTRY(2000000)
 #endif
-#if defined(B2500000) || defined(CBR_2500000)
+#ifdef B2500000
 	BAUDENTRY(2500000)
 #endif
-#if defined(B3000000) || defined(CBR_3000000)
+#ifdef B3000000
 	BAUDENTRY(3000000)
 #endif
-#if defined(B3500000) || defined(CBR_3500000)
+#ifdef B3500000
 	BAUDENTRY(3500000)
 #endif
-#if defined(B4000000) || defined(CBR_4000000)
+#ifdef B4000000
 	BAUDENTRY(4000000)
 #endif
 	{0, 0}			/* Terminator */
@@ -133,6 +126,7 @@ static const struct baudentry *round_baud(unsigned int baud)
 	msg_pinfo("Using slowest possible baudrate: %d.\n", sp_baudtable[0].baud);
 	return &sp_baudtable[0];
 }
+#endif 
 
 /* Uses msg_perr to print the last system error.
  * Prints "Error: " followed first by \c msg and then by the description of the last error retrieved via
@@ -169,8 +163,7 @@ int serialport_config(fdtype fd, int baud)
 		return 1;
 	}
 	if (baud >= 0) {
-		const struct baudentry *entry = round_baud(baud);
-		dcb.BaudRate = entry->flag;
+		dcb.BaudRate = baud;
 	}
 	dcb.ByteSize = 8;
 	dcb.Parity = NOPARITY;

--- a/serprog.c
+++ b/serprog.c
@@ -331,6 +331,7 @@ static const struct par_master par_master_serprog = {
 		.chip_writew		= fallback_chip_writew,
 		.chip_writel		= fallback_chip_writel,
 		.chip_writen		= fallback_chip_writen,
+		.chip_poll		= fallback_chip_poll,
 };
 
 static enum chipbustype serprog_buses_supported = BUS_NONE;

--- a/serprog.c
+++ b/serprog.c
@@ -888,7 +888,7 @@ static int sp_check_opbuf_usage(int bytes_to_be_added)
 	if (sp_device_opbuf_size <= (sp_opbuf_usage + bytes_to_be_added)) {
 		/* If this happens in the middle of a page load the page load will probably fail. */
 		msg_pwarn(MSGHEADER "Warning: executed operation buffer due to size reasons\n");
-		if (sp_execute_opbuf() != 0)
+		if (sp_execute_opbuf_noflush() != 0)
 			return 1;
 	}
 	return 0;

--- a/serprog.c
+++ b/serprog.c
@@ -342,26 +342,28 @@ int serprog_init(void)
 	unsigned char rbuf[3];
 	unsigned char c;
 	char *device;
-	char *baudport;
 	int have_device = 0;
 
-	/* the parameter is either of format "dev=/dev/device:baud" or "ip=ip:port" */
+	/* the parameter is either of format "dev=/dev/device[:baud]" or "ip=ip:port" */
 	device = extract_programmer_param("dev");
 	if (device && strlen(device)) {
-		baudport = strstr(device, ":");
-		if (baudport) {
+		char *baud_str = strstr(device, ":");
+		if (baud_str) {
 			/* Split device from baudrate. */
-			*baudport = '\0';
-			baudport++;
+			*baud_str = '\0';
+			baud_str++;
 		}
-		if (!baudport || !strlen(baudport)) {
-			msg_perr("Error: No baudrate specified.\n"
-				 "Use flashrom -p serprog:dev=/dev/device:baud\n");
-			free(device);
-			return 1;
-		}
-		if (strlen(device)) {
-			sp_fd = sp_openserport(device, atoi(baudport));
+		int baud;
+		/* Convert baud string to value.
+		 * baud_str is either NULL (if strstr can't find the colon), points to the \0 after the colon
+		 * if no characters where given after the colon, or a string to convert... */
+		if (baud_str == NULL || *baud_str == '\0') {
+			baud = -1;
+			msg_pdbg("No baudrate specified, using the hardware's defaults.\n");
+		} else
+			baud = atoi(baud_str); // FIXME: replace atoi with strtoul
+		if (strlen(device) > 0) {
+			sp_fd = sp_openserport(device, baud);
 			if (sp_fd == SER_INV_FD) {
 				free(device);
 				return 1;
@@ -371,7 +373,7 @@ int serprog_init(void)
 	}
 	if (device && !strlen(device)) {
 		msg_perr("Error: No device specified.\n"
-			 "Use flashrom -p serprog:dev=/dev/device:baud\n");
+			 "Use flashrom -p serprog:dev=/dev/device[:baud]\n");
 		free(device);
 		return 1;
 	}
@@ -386,20 +388,20 @@ int serprog_init(void)
 		return 1;
 	}
 	if (device && strlen(device)) {
-		baudport = strstr(device, ":");
-		if (baudport) {
+		char *port = strstr(device, ":");
+		if (port) {
 			/* Split host from port. */
-			*baudport = '\0';
-			baudport++;
+			*port = '\0';
+			port++;
 		}
-		if (!baudport || !strlen(baudport)) {
+		if (!port || !strlen(port)) {
 			msg_perr("Error: No port specified.\n"
 				 "Use flashrom -p serprog:ip=ipaddr:port\n");
 			free(device);
 			return 1;
 		}
 		if (strlen(device)) {
-			sp_fd = sp_opensocket(device, atoi(baudport));
+			sp_fd = sp_opensocket(device, atoi(port));
 			if (sp_fd < 0) {
 				free(device);
 				return 1;

--- a/serprog.c
+++ b/serprog.c
@@ -322,6 +322,8 @@ static uint8_t serprog_chip_readb(const struct flashctx *flash,
 				  const chipaddr addr);
 static void serprog_chip_readn(const struct flashctx *flash, uint8_t *buf,
 			       const chipaddr addr, size_t len);
+static void serprog_chip_poll(const struct flashctx *flash, const chipaddr addr,
+				uint8_t mask, int data_or_toggle, unsigned int delay);
 static const struct par_master par_master_serprog = {
 		.chip_readb		= serprog_chip_readb,
 		.chip_readw		= fallback_chip_readw,
@@ -331,7 +333,7 @@ static const struct par_master par_master_serprog = {
 		.chip_writew		= fallback_chip_writew,
 		.chip_writel		= fallback_chip_writel,
 		.chip_writen		= fallback_chip_writen,
-		.chip_poll		= fallback_chip_poll,
+		.chip_poll		= serprog_chip_poll,
 };
 
 static enum chipbustype serprog_buses_supported = BUS_NONE;
@@ -884,6 +886,58 @@ static void serprog_chip_readn(const struct flashctx *flash, uint8_t * buf,
 	}
 	if (lenm)
 		sp_do_read_n(&(buf[addrm-addr]), addrm, lenm); // FIXME: return error
+}
+
+static void serprog_chip_poll(const struct flashctx *flash, const chipaddr addr,
+				uint8_t mask, int data_or_toggle, unsigned int delay)
+{
+	uint8_t pbuf[8];
+	uint8_t lmask = mask;
+	int i,shift = -1;
+	for (i=0;i<8;i++) {
+		if (lmask & 1) {
+			if (lmask & 0xFE) break; /* Multi-bit mask not acceleratable */
+			shift = i;
+			break;
+		}
+		lmask = lmask >> 1;
+	}
+
+	if ((sp_check_commandavail(delay ? S_CMD_O_POLL_DLY : S_CMD_O_POLL) == 0) || (shift < 0)) {
+		fallback_chip_poll(flash, addr, mask, data_or_toggle, delay);
+		return;
+	}
+
+	if ((sp_max_write_n) && (sp_write_n_bytes)) {
+		if (sp_pass_writen() != 0) {
+			msg_perr("Error: could not transfer write buffer\n");
+			return;
+		}
+	}
+	if (data_or_toggle > 0) data_or_toggle &= mask;
+
+	pbuf[0] = (data_or_toggle < 0 ? 0x10 : 0) | (data_or_toggle > 0 ? 0x20 : 0) | shift;
+	pbuf[1] = ((addr >> 0) & 0xFF);
+	pbuf[2] = ((addr >> 8) & 0xFF);
+	pbuf[3] = ((addr >> 16) & 0xFF);
+	if (delay) {
+		sp_check_opbuf_usage(9);
+		pbuf[4] = ((delay >> 0) & 0xFF);
+		pbuf[5] = ((delay >> 8) & 0xFF);
+		pbuf[6] = ((delay >> 16) & 0xFF);
+		pbuf[7] = ((delay >> 24) & 0xFF);
+		sp_stream_buffer_op(S_CMD_O_POLL_DLY, 8, pbuf);
+		sp_opbuf_usage += 9;
+	} else {
+		sp_check_opbuf_usage(5);
+		sp_stream_buffer_op(S_CMD_O_POLL, 4, pbuf);
+		sp_opbuf_usage += 5;
+	}
+	/* This used to be (in the fallback) a native exec point, so if
+	 * opbuf more than 1/3 full, do the exec. */
+	if (sp_opbuf_usage >= (sp_device_opbuf_size / 3)) {
+		sp_execute_opbuf_noflush();
+	}
 }
 
 void serprog_delay(unsigned int usecs)

--- a/serprog.c
+++ b/serprog.c
@@ -268,7 +268,7 @@ static int sp_docommand(uint8_t command, uint32_t parmlen,
 	if (c == S_NAK)
 		return 1;
 	if (c != S_ACK) {
-		msg_perr("Error: invalid response 0x%02X from device\n", c);
+		msg_perr("Error: invalid response 0x%02X from device (to command 0x%02X)\n", c, command);
 		return 1;
 	}
 	if (retlen) {

--- a/serprog.c
+++ b/serprog.c
@@ -371,12 +371,15 @@ int serprog_init(void)
 			have_device++;
 		}
 	}
+
+#if !IS_WINDOWS
 	if (device && !strlen(device)) {
 		msg_perr("Error: No device specified.\n"
 			 "Use flashrom -p serprog:dev=/dev/device[:baud]\n");
 		free(device);
 		return 1;
 	}
+#endif
 	free(device);
 
 #if !IS_WINDOWS
@@ -416,14 +419,19 @@ int serprog_init(void)
 		return 1;
 	}
 	free(device);
+#endif
 
 	if (!have_device) {
+#if IS_WINDOWS
+		msg_perr("Error: No device specified.\n"
+			 "Use flashrom -p serprog:dev=comN[:baud]\n");
+#else
 		msg_perr("Error: Neither host nor device specified.\n"
 			 "Use flashrom -p serprog:dev=/dev/device:baud or "
 			 "flashrom -p serprog:ip=ipaddr:port\n");
+#endif
 		return 1;
 	}
-#endif
 
 	if (register_shutdown(serprog_shutdown, NULL))
 		return 1;

--- a/serprog.h
+++ b/serprog.h
@@ -23,3 +23,5 @@
 #define S_CMD_O_SPIOP		0x13	/* Perform SPI operation.			*/
 #define S_CMD_S_SPI_FREQ	0x14	/* Set SPI clock frequency			*/
 #define S_CMD_S_PIN_STATE	0x15	/* Enable/disable output drivers		*/
+#define S_CMD_O_POLL		0x17	/* Write to opbuf: poll				*/
+#define S_CMD_O_POLL_DLY	0x18	/* Write to opbuf: poll w/ delay		*/


### PR DESCRIPTION
This is a small cleanup of serprog improvements into an order where the first commits should be easier to get upstreamed than the later ones, and request made just so we can keep a better track of this stuff...
I included your serial port related improvements and my Ack to them.

I'm not expecting anything anytime soon, but decided it'd be good to open the discussion about these.
And yeah I'd say the first 7 commits* (upto/including stream SPI operations) should be simple enough, mostly fixes.

*EDIT: github has some weirdness with the order in which it displays commits in the pull request (maybe tries to be chronological since i reordered some? i dont know), but the
https://github.com/urjaman/flashrom/commits/sp-upstream log there is in the order i meant (or reverse if you're that pedantic..).

The rest is mostly the on-device polling system and the infrastructure changes it needed to be useful.