### PR TITLE
Marked W25Q80.W to tested for Read, Write, Probe, Erase

### DIFF
--- a/flashchips.c
+++ b/flashchips.c
@@ -14224,7 +14224,7 @@ const struct flashchip flashchips[] = {
 		.page_size	= 256,
 		/* OTP: 256B total; read 0x48; write 0x42, erase 0x44, read ID 0x4B */
 		.feature_bits	= FEATURE_WRSR_WREN | FEATURE_OTP,
-		.tested		= TEST_UNTESTED,
+		.tested		= TEST_OK_PREW,
 		.probe		= probe_spi_rdid,
 		.probe_timing	= TIMING_ZERO,
 		.block_erasers	=


### PR DESCRIPTION
mm@lapos:~/Projektek/flashrom$ ./flashrom -p usb8451_spi:voltage=1.8 -w /tmp/PEX_PADDED.bin 
flashrom v0.9.7-unknown on Linux 3.13.0-70-generic (x86_64)
flashrom is free software, get the source code at http://www.flashrom.org

Calibrating delay loop... OK.
Found USB device (3923:7514).
USB-8452 IO voltage set to: 1.8 V
USB-8452 SCK frequency set to: 50.00 MHz
Found Winbond flash chip "W25Q80.W" (1024 kB, SPI) on usb8451_spi.
===
This flash part has status UNTESTED for operations: PROBE READ ERASE WRITE
The test status of this chip may have been updated in the latest development
version of flashrom. If you are running the latest development version,
please email a report to flashrom@flashrom.org if any of the above operations
work correctly for you with this flash part. Please include the flashrom
output with the additional -V option for all operations you tested (-V, -Vr,
-VE, -Vw), and mention which mainboard or programmer you tested.
Please mention your board in the subject line. Thanks for your help!
Reading old flash chip contents... done.
Erasing and writing flash chip... 
Erase/write done.
Verifying flash... VERIFIED.


No verbose logs sorry. 